### PR TITLE
Remove direct runtime dependency on Test::Version

### DIFF
--- a/dist.ini
+++ b/dist.ini
@@ -69,9 +69,6 @@ workflow = macos
 workflow = windows
 workflow = cygwin
 
-[Prereqs]
-  Test::Version = 1 ; optionally required by why install this without it
-
 [Prereqs / TestRequires]
   Test::Version = 1
   Dist::Zilla   = 5.036


### PR DESCRIPTION
This plugin doesn't use Test::Version, but generates a test that uses it. Building a dist using this plugin doesn't need Test::Version for anything, and is an extraneous dependency if you don't intent to run the test, or are running it on a different system.